### PR TITLE
CASMTRIAGE-2090: Build RPM and Python module using Python 3.6

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -53,59 +53,15 @@ pipeline {
     }
 
     stages {
-        stage("Python module") {
+        stage("Python module and RPM") {
             agent {
                 docker {
                     label "metal-gcp-builder"
-                    image "arti.dev.cray.com/dstbuildenv-docker-master-local/cray-alpine3_build_environment:latest"
-                    args "-u root"
+                    image "arti.dev.cray.com/dstbuildenv-docker-master-local/cray-sle15sp2_build_environment:latest"
                 }
             }
             environment {
                 PYTHON_MODULE_NAME = "cfs-ssh-trust"
-            }
-            stages {
-                stage("Install Necessary Tools") {
-                    steps {
-                        sh """
-                            apk add --no-cache --virtual .build-deps g++ python3-dev libffi-dev openssl-dev py3-pip curl bash make
-                            apk add --no-cache --update python3 && pip3 install --upgrade pip setuptools
-                            pip3 install wheel
-                        """
-                    }
-                }
-
-                stage("Clone cms_meta_tools repo") {
-                    steps { cloneCmsMetaTools() }
-                }
-
-                stage("Set Versions") {
-                    steps { setVersions() }
-                }
-
-                stage("runBuildPrep") {
-                    steps { runBuildPrep() }
-                }
-
-                stage("Lint") {
-                    steps { runLint() }
-                }
-                stage('Build Package') {
-                    steps { sh "make pymod" }
-                }
-                stage('Publish') {
-                    steps {
-                        publishCsmPythonModules(module: env.PYTHON_MODULE_NAME, isStable: env.IS_STABLE)
-                    }
-                }
-            }
-        }
-
-        stage("Chart, Image, and RPM") {
-            agent {
-                label "metal-gcp-builder"
-            }
-            environment {
                 BUILD_METADATA = getRpmRevision(isStable: env.IS_STABLE)
             }
             stages {
@@ -138,6 +94,46 @@ pipeline {
                     }
                 }
 
+                stage('Build Python Module') {
+                    steps { sh "make pymod" }
+                }
+
+                stage('Build RPM') {
+                    environment {BUILD_METADATA = getRpmRevision(isStable: env.IS_STABLE)}
+                    steps { sh "make rpm" }
+                }
+
+                stage('Publish') {
+                    steps {
+                        publishCsmPythonModules(module: env.PYTHON_MODULE_NAME, isStable: env.IS_STABLE)
+                        publishCsmRpms(component: env.NAME, pattern: "dist/rpmbuild/RPMS/x86_64/*.rpm", arch: "x86_64", isStable: env.IS_STABLE)
+                        publishCsmRpms(component: env.NAME, pattern: "dist/rpmbuild/SRPMS/*.rpm", arch: "src", isStable: env.IS_STABLE)
+                    }
+                }
+            }
+        }
+
+        stage("Chart and Image") {
+            agent {
+                label "metal-gcp-builder"
+            }
+            stages {
+                stage("Clone cms_meta_tools repo") {
+                    steps { cloneCmsMetaTools() }
+                }
+
+                stage("Set Versions") {
+                    steps { setVersions() }
+                }
+
+                stage("runBuildPrep") {
+                    steps { runBuildPrep() }
+                }
+
+                stage("Lint") {
+                    steps { runLint() }
+                }
+
                 stage("Build") {
                     parallel {
                         stage('Image') {
@@ -159,11 +155,6 @@ pipeline {
                                 sh "make chart"
                             }
                         }
-
-                        stage('Rpm') {
-                            environment {BUILD_METADATA = getRpmRevision(isStable: env.IS_STABLE)}
-                            steps { sh "make rpm" }
-                        }
                     }
                 }
 
@@ -175,8 +166,6 @@ pipeline {
                     steps {
                         publishCsmDockerImage(image: env.NAME, tag: env.DOCKER_VERSION, isStable: env.IS_STABLE)
                         publishCsmHelmCharts(component: env.NAME, chartsPath: "${WORKSPACE}/kubernetes/.packaged", isStable: env.IS_STABLE)
-                        publishCsmRpms(component: env.NAME, pattern: "dist/rpmbuild/RPMS/x86_64/*.rpm", arch: "x86_64", isStable: env.IS_STABLE)
-                        publishCsmRpms(component: env.NAME, pattern: "dist/rpmbuild/SRPMS/*.rpm", arch: "src", isStable: env.IS_STABLE)
                     }
                 }
             }

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,7 @@ lint:
 		./cms_meta_tools/scripts/runLint.sh
 
 prepare:
+		pip3 install --upgrade pip setuptools wheel
 		rm -rf $(BUILD_DIR)
 		mkdir -p $(BUILD_DIR)/SPECS $(BUILD_DIR)/SOURCES
 		cp $(SPEC_FILE) $(BUILD_DIR)/SPECS/
@@ -75,6 +76,8 @@ rpm_build_source:
 		BUILD_METADATA=$(BUILD_METADATA) rpmbuild -ts $(SOURCE_PATH) --define "_topdir $(BUILD_DIR)"
 
 rpm_build:
+		uname -a
+		cat /etc/*release*
 		BUILD_METADATA=$(BUILD_METADATA) rpmbuild -ba $(SPEC_FILE) --define "_topdir $(BUILD_DIR)" --define "python3_sitelib $(PYTHON_SITE_PACKAGES_PATH)"
 
 pymod:

--- a/setup.py
+++ b/setup.py
@@ -25,8 +25,7 @@ import setuptools
 with open("README.md", "r") as fh:
     long_description = fh.read().strip()
 
-with open(".version", "r") as fh:
-    version_str = fh.read().strip()
+version_str = "@VERSION@"
 
 package_dir = {'cfsssh':                        'src/cfsssh',
                'cfsssh.cloudinit':              'src/cfsssh/cloudinit',
@@ -43,14 +42,14 @@ setuptools.setup(
     description="CFS Trust Setup",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="https://stash.us.cray.com/projects/SCMS/repos/cfs-trust/browse",
+    url="https://github.com/Cray-HPE/cfs-trust",
     package_dir = package_dir,
     packages = list(package_dir.keys()),
     keywords="vault ssh cfs kubernetes trust certificates",
-    classifiers=(
-        "Programming Language :: Python :: 3.8",
+    classifiers=[
+        "Programming Language :: Python :: 3.6",
         "License :: Other/Proprietary License",
         "Topic :: Software Development :: Libraries :: Python Modules",
         "Topic :: System :: Systems Administration",
-    ),
+    ],
 )

--- a/update_versions.conf
+++ b/update_versions.conf
@@ -17,3 +17,6 @@
 
 sourcefile: .chart_version
 targetfile: kubernetes/cfs-trust/Chart.yaml
+
+sourcefile: .version
+targetfile: setup.py


### PR DESCRIPTION
### Summary and Scope
One of the problems uncovered in CASMTRIAGE-2087 and CASMTRIAGE-2090 was that the cfs-trust RPM being built from github was using Python 3.8 in the build process, and as a consequence the RPM it created was installing the Python module into a different location on the system than what cfs-state-reporter was expecting. 

The short term fix for this was to make manifest PRs to use the latest cfs-trust version that had still been built using the DST pipeline. The long term fix is to make the github builds work the same way that the DST builds did in this regard.

This PR contains the long-term fix, which more than anything consisted of doing the RPM and Python module builds in a different Docker container.

### Issues and Related PRs
CASMTRIAGE-2087 and CASMTRIAGE-2090

### Testing
I tested the github-built RPM on ego. I verified that it installed the Python module into the expected location, and I and verified that (after restarting it) cfs-state-reporter still functioned as expected.

### Risks and Mitigations
Very low risk. The problem being solved is just that the RPM was not installing the module in the right place. There are no code changes to the module itself in this PR. If this PR was not doing what it was supposed to be doing, then I would have expected to see problems on ego when I tested t.
