### PR TITLE
CASMCMS-7678: Use api-gw-service-nmn.local not api_gw_service.local

### DIFF
--- a/src/cfsssh/cloudinit/bss.py
+++ b/src/cfsssh/cloudinit/bss.py
@@ -40,7 +40,7 @@ if in_cluster():
     METADATA_ENDPOINT = '%s/%s' % (SERVICE_ENDPOINT, METADATA_SUFFIX)
 else:
     PROTOCOL = 'http'
-    DNS_NAME = 'api_gw_service.local'
+    DNS_NAME = 'api-gw-service-nmn.local'
     PARAMETERS_ENDPOINT = '%s://%s/%s' % (PROTOCOL, DNS_NAME, BOOT_PARAM_SUFFIX)
     METADATA_ENDPOINT = '%s://%s:8888/%s' %(PROTOCOL, DNS_NAME, METADATA_SUFFIX)
 


### PR DESCRIPTION
## Summary and Scope

cfs-state-reporter fails to start in csm-1.2 because cfs-trust has an error making an API call. This error is because it is using an outdated hostname for the gateway. It is using _api_gw_service.local_ but it should be using _api-gw-service-nmn.local_. Without this change, cfs-trust (and therefore cfs-state-reporter) will not work on NCNs. (Note that this does not impact these when running inside a pod, as they use a different hostname in that case).

This change is backwards compatible in the sense that the new style hostname works fine even on csm-1.0.

## Issues and Related PRs

* Resolves issue reported in [CASMTRIAGE-2651](https://connect.us.cray.com/jira/browse/CASMTRIAGE-2651)

## Testing

### Tested on:

  * `wasp`

### Test description:

I installed the fixed cfs-trust RPM on wasp, restarted cfs-state-reporter, and verified that it got past this problem. (cfs-state-reporter still ultimately failed to start, but [for unrelated reasons](https://connect.us.cray.com/jira/browse/CASMTRIAGE-2674)).

I did not run our cmsdev tests because as noted, cfs-state-reporter still ultimately was not working, so those tests still would have failed. I am not aware of any tests I could have run in this situation, beyond verifying that cfs-state-reporter was able to get beyond the original problem when trying to start.

No upgrade or downgrade testing was done, but that's not really an applicable test for our RPMs anyway, since currently they are installed only when we are deploying an entire new NCN image. But I did force install this RPM over the current RPM, which follows the same process as an RPM upgrade or downgrade would -- the force is required only because I installed a development version whose version number was less than that of the installed version.

No new tests were created for this change. The existing tests caught the issue appropriately.

## Risks and Mitigations

I am not aware of any known issues with this change. Its scope is very limited.

## Pull Request Checklist

- [N/A] Version number(s) incremented, if applicable
- [N/A] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [N/A] CHANGELOG.md updated
Repo has no CHANGELOG.md
- [X] Testing is appropriate and complete, if applicable
- [N/A] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

