### PR TITLE
CASMCMS-7783: Patch BSS metadata key for CFS Instead of Put

### DIFF
--- a/src/cfsssh/cloudinit/bss.py
+++ b/src/cfsssh/cloudinit/bss.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 Hewlett Packard Enterprise Development LP
+# Copyright 2020-2022 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -62,10 +62,10 @@ def get_global_metadata_key(key, session=None):
     # This will raise a key error if it isn't defined!
     return obj['Global'][key]
 
-def put_global_metadata_key(key, value, session=None):
+def patch_global_metadata_key(key, value, session=None):
     session = session or requests_retry_session()
     put_payload = {"hosts" : ["Global"], 'cloud-init': {'meta-data': {key: value}}}
-    response = session.put(PARAMETERS_ENDPOINT, json=put_payload)
+    response = session.patch(PARAMETERS_ENDPOINT, json=put_payload)
     try:
         response.raise_for_status()
     except Exception as exc:

--- a/src/cfsssh/cloudinit/bss.py
+++ b/src/cfsssh/cloudinit/bss.py
@@ -1,4 +1,25 @@
-# Copyright 2020-2022 Hewlett Packard Enterprise Development LP
+#
+# MIT License
+#
+# (C) Copyright 2020-2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/src/cfsssh/setup/service/__main__.py
+++ b/src/cfsssh/setup/service/__main__.py
@@ -1,4 +1,25 @@
-# Copyright 2020-2022 Hewlett Packard Enterprise Development LP
+#
+# MIT License
+#
+# (C) Copyright 2020-2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),


### PR DESCRIPTION
## Summary and Scope

This mod changes the population behavior for cfs-trust; this migrates
the behavior over to a patch operation in order to be a good citizen for
any service that ends up populating information afterwards. Normally, we
don't re-PUT once our key is there, and since our services is one of the
first to push content into the bss metadata service, there is no
problem.

However, during an upgrade or scenarios where cfs-trust metadata goes
missing, subsequent PUT operations zero any incidental keys stored in
BSS metadata global section; this information then needs to be recovered
(sometimes manually).

Finally, this mod updates the behavior of cfs-trust and changes it to
re-populate our missing key if it ever goes missing for whatever reason.
Previously, a pod restart would accomplish this similar behavior but now
that is no longer needed. The existing resigning/republishing loop is
used to accomplish this, so BSS metadata healing happens every 6 hours
or so.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [CASMCMS-7783](https://jira-pro.its.hpecorp.net:8443/browse/CASMCMS-7783)

## Testing

Replaced functionality was exercised within the cfs-trust pod on wasp; all bss-metadata was backed up prior to testing to ensure the PATCH function matched the lossless behavior desired.

### Tested on:
  * wasp


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] Testing is appropriate and complete, if applicable

