### PR TITLE
Fix LICENSE file to standard.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-(C) Copyright [2021] Hewlett Packard Enterprise Development LP
+(C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),


### PR DESCRIPTION
## Summary and Scope

This mod corrects the license file to match the new accepted license syntax. It also bumps the version to 1.4.2 for this release branch, which correctly aligns it with the monotonically increasing versions/tags required for release.