### PR TITLE
CASMTRIAGE-3835: Escalate pod priority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.1] - 8/18/22
+### Fixed
+- Escalated pod priority so that configuration has a better chance of running when a node is cordoned
+
 ## [1.5.0] - 2022-07-14
 ### Added
 - Support for SLES SP4

--- a/kubernetes/cfs-trust/values.yaml
+++ b/kubernetes/cfs-trust/values.yaml
@@ -38,6 +38,7 @@ cray-service:
   nodeSelector:
     node-discovery.cray.com/networks.node_management: "true"
   replicaCount: 1
+  priorityClassName: csm-high-priority-service
   containers:
     cfs-trust:
       name: "cfs-trust"


### PR DESCRIPTION
## Summary and Scope

Escalates the pods to a high priority to improve CFS' ability to run when the system is partially down.

## Issues and Related PRs

* Resolves CASMTRIAGE-3835

## Testing

### Tested on:

  * Mug

### Test description:

Deployed the new image chart and tested basic functions

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

