### PR TITLE
CASMINST-5443: Authenticate to CSM's artifactory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - Spelling corrections.
+- Authenticate to CSM's artifactory
 
 ## [1.5.1] - 8/18/22
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,10 +28,11 @@ COPY /src/ /app/src
 COPY /src/cfsssh/cloudinit/ /app/src/cloudinit
 COPY setup.py README.md .version gitInfo.txt /app/
 ADD constraints.txt requirements.txt /app/
-RUN apk add --upgrade --no-cache apk-tools &&  \
-	apk update && \
-	apk add --no-cache linux-headers gcc g++ python3-dev py3-pip musl-dev libffi-dev openssl-dev git jq curl openssh-client && \
-	apk -U upgrade --no-cache && \
+RUN --mount=type=secret,id=netrc,target=/root/.netrc \
+    apk add --upgrade --no-cache apk-tools &&  \
+    apk update && \
+    apk add --no-cache linux-headers gcc g++ python3-dev py3-pip musl-dev libffi-dev openssl-dev git jq curl openssh-client && \
+    apk -U upgrade --no-cache && \
     python3 -m pip install --upgrade pip && \
     pip3 install --no-cache-dir -U pip && \
     pip3 install --no-cache-dir -r requirements.txt

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -52,7 +52,6 @@ pipeline {
         PUBLISH_SP2 = "sle-15sp2"
         PUBLISH_SP3 = "sle-15sp3"
         PUBLISH_SP4 = "sle-15sp4"
-	jenkinsUtils.writeNetRc()
     }
 
     stages {
@@ -84,7 +83,7 @@ pipeline {
                     image "arti.hpc.amslabs.hpecorp.net/dstbuildenv-docker-master-local/cray-sle15sp3_build_environment:latest"
                     reuseNode true
                     // Support docker in docker for clamav scan
-                    args "-v /var/run/docker.sock:/var/run/docker.sock -v /usr/bin/docker:/usr/bin/docker -v ${HOME}/.netrc:/root/.netrc --group-add 999"
+                    args "-v /var/run/docker.sock:/var/run/docker.sock -v /usr/bin/docker:/usr/bin/docker --group-add 999"
                 }
             }
             environment {

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -52,6 +52,7 @@ pipeline {
         PUBLISH_SP2 = "sle-15sp2"
         PUBLISH_SP3 = "sle-15sp3"
         PUBLISH_SP4 = "sle-15sp4"
+	jenkinsUtils.writeNetRc()
     }
 
     stages {
@@ -83,7 +84,7 @@ pipeline {
                     image "arti.hpc.amslabs.hpecorp.net/dstbuildenv-docker-master-local/cray-sle15sp3_build_environment:latest"
                     reuseNode true
                     // Support docker in docker for clamav scan
-                    args "-v /var/run/docker.sock:/var/run/docker.sock -v /usr/bin/docker:/usr/bin/docker --group-add 999"
+                    args "-v /var/run/docker.sock:/var/run/docker.sock -v /usr/bin/docker:/usr/bin/docker -v ${HOME}/.netrc:/root/.netrc --group-add 999"
                 }
             }
             environment {

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -48,6 +48,7 @@ pipeline {
         NAME = "cfs-trust"
         DESCRIPTION = "Configuration Framework Service Trust Environment"
         IS_STABLE = getBuildIsStable()
+	DOCKER_BUILDKIT = "1"
         PUBLISH_SP2 = "sle-15sp2"
         PUBLISH_SP3 = "sle-15sp3"
         PUBLISH_SP4 = "sle-15sp4"

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,10 @@ BUILD_DIR ?= $(PWD)/dist/rpmbuild
 SOURCE_PATH := ${BUILD_DIR}/SOURCES/${SOURCE_NAME}.tar.bz2
 PYTHON_SITE_PACKAGES_PATH ?= $(shell python3 -c 'import site; print(site.getsitepackages()[0])')
 
+ifneq ($(wildcard ${HOME}/.netrc),)
+        DOCKER_ARGS ?= --secret id=netrc,src=${HOME}/.netrc
+endif
+
 all : runbuildprep lint prepare image chart rpm pymod
 chart: chart_setup chart_package chart_test
 rpm: rpm_package_source rpm_build_source rpm_build


### PR DESCRIPTION
## Summary and Scope

Authenticate to CSM's artifactory when using pip to access CSM's csm-python-modules.


## Issues and Related PRs


* Resolves CASMINST-5443

## Testing


### Tested on:

  * Build environment

### Test description:

It builds successfully.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)?
- Were continuous integration tests run? If not, why?
- Was upgrade tested? If not, why?
- Was downgrade tested? If not, why?
- Were new tests (or test issues/Jiras) created for this change?

## Risks and Mitigations

_Are there known issues with these changes? Any other special considerations?_


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

