### PR TITLE
CASMINST-5443: Authenticate to CSM's artifactory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for CFS Trust
-# Copyright 2019-2021 Hewlett Packard Enterprise Development LP
+# Copyright 2019-2022 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -28,10 +28,11 @@ COPY /src/ /app/src
 COPY /src/cfsssh/cloudinit/ /app/src/cloudinit
 COPY setup.py README.md .version gitInfo.txt /app/
 ADD constraints.txt requirements.txt /app/
-RUN apk add --upgrade --no-cache apk-tools &&  \
-	apk update && \
-	apk add --no-cache linux-headers gcc g++ python3-dev py3-pip musl-dev libffi-dev openssl-dev git jq curl openssh-client && \
-	apk -U upgrade --no-cache && \
+RUN --mount=type=secret,id=netrc,target=/root/.netrc \
+    apk add --upgrade --no-cache apk-tools &&  \
+    apk update && \
+    apk add --no-cache linux-headers gcc g++ python3-dev py3-pip musl-dev libffi-dev openssl-dev git jq curl openssh-client && \
+    apk -U upgrade --no-cache && \
     python3 -m pip install --upgrade pip && \
     pip3 install --no-cache-dir -U pip && \
     pip3 install --no-cache-dir -r requirements.txt

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -23,6 +23,7 @@ pipeline {
         NAME = "cfs-trust"
         DESCRIPTION = "Configuration Framework Service Trust Environment"
         IS_STABLE = getBuildIsStable()
+	DOCKER_BUILDKIT = "1"
         PUBLISH_SP2 = "sle-15sp2"
         PUBLISH_SP3 = "sle-15sp3"
     }

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2019-2021 Hewlett Packard Enterprise Development LP
+# Copyright 2019-2022 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -37,6 +37,10 @@ SOURCE_NAME ?= ${NAME}-${RPM_VERSION}
 BUILD_DIR ?= $(PWD)/dist/rpmbuild
 SOURCE_PATH := ${BUILD_DIR}/SOURCES/${SOURCE_NAME}.tar.bz2
 PYTHON_SITE_PACKAGES_PATH ?= $(shell python3 -c 'import site; print(site.getsitepackages()[0])')
+
+ifneq ($(wildcard ${HOME}/.netrc),)
+        DOCKER_ARGS ?= --secret id=netrc,src=${HOME}/.netrc
+endif
 
 all : runbuildprep lint prepare image chart rpm pymod
 chart: chart_setup chart_package chart_test


### PR DESCRIPTION
## Summary and Scope

Authenticate to CSM's artifactory when using pip to access CSM's csm-python-modules.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves CASMINST-5443

## Testing


### Tested on:

  * Tested by committing it to the build environment. There was not an artifactory available with the correct permissions to test against.

### Test description:

See above.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? No.
- Were continuous integration tests run? If not, why? No.
- Was upgrade tested? If not, why? No.
- Was downgrade tested? If not, why? No.
- Were new tests (or test issues/Jiras) created for this change? No.

## Risks and Mitigations
Low.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

