### PR TITLE
CASMCMS-8713: Bump PyYAML from 5.4.1 to 6.0.1 to prevent build issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.6] - 2023-07-18
+### Dependencies
+- Bump `PyYAML` from 5.4.1 to 6.0.1 to avoid build issue caused by https://github.com/yaml/pyyaml/issues/601
+
 ## [1.6.5] - 2023-06-22
 ### Added
 - Build SLES SP5 RPM

--- a/constraints.txt
+++ b/constraints.txt
@@ -9,7 +9,7 @@ oauthlib==3.1.0
 pyasn1==0.4.8
 pyasn1-modules==0.2.8
 python-dateutil==2.8.1
-PyYAML==5.4.1
+PyYAML==6.0.1
 requests==2.25.1
 requests-oauthlib==1.3.0
 rsa==4.7


### PR DESCRIPTION
Builds in this repo are failing due to the problem documented in [CASMCMS-8713](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8713). Moving to PyYAML 6.0.1 resolves the problem. This PR moves PyYAML from 5.4.1 to 6.0.1.

A similar change is being made to a number of CSM repositories that are similarly affected.

There is no functional difference between `PyYAML` 6.0 and 6.0.1. The only difference is that 6.0.1 imposes a restriction on the Cython version used to build the module during installs. Specifically, it requires Cython < 3, which is the same behavior as `PyYAML` 6.0 had up until Cython 3 was released.

However, this repo is currently using `PyYAML` 5.4.1. Unfortunately, there is no `PyYAML` fix for that version. The maintainers have said that they will consider backporting a fix, but are not willing to commit to it. This leaves affected users of 5.4.1 two options -- move to 6.0.1 or work around the problem. I think for this repository, moving to 6.0.1 is the better solution. I have reviewed the breaking changes between 5.4 and 6.0, and they are:

* Dropped support for Python 2.7 and 3.5
* The `load()` and `load_all()` functions now require the `Loader` argument (previously it was optional).
* Removed `YAMLLoadWarning` definition (since it was warning about the absence of the previous argument)

This repo is using an Alpine version which is using a Python version > 3.5, so the dropped support doesn't matter. I searched the Python code in the repo, and it does not call either of the functions with the newly required argument. It also does not use the removed `YAMLLoadWarning`. So the move to 6.0.1 should cause no problems.