### PR TITLE
CASMCMS-9101: Use requests-retry-session package instead of duplicating its code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.7.2] - 2024-08-16
 ### Changed
 - Print list of installed Python modules after pip installs in Dockerfile, for logging purposes.
 
 ### Dependencies
 - Instead of using `update_external_versions` to find the latest patch version of
-liveness, instead just pin the major/minor number directly in [`constraints.txt`](constraints.txt).
+  liveness, instead just pin the major/minor number directly in [`constraints.txt`](constraints.txt).
+- Use `requests_retry_session` module instead of duplicating its code.
 
 ## [1.7.1] - 2024-06-28
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,24 +21,20 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-FROM artifactory.algol60.net/docker.io/alpine:3.15 as service
+FROM artifactory.algol60.net/docker.io/alpine:3.15 AS service
 WORKDIR /app
-RUN mkdir /app/src
-COPY /src/ /app/src
-COPY /src/cfsssh/cloudinit/ /app/src/cloudinit
-COPY setup.py README.md .version gitInfo.txt /app/
-ADD constraints.txt requirements.txt /app/
+COPY constraints.txt requirements.txt dist/*.whl /app/
 RUN --mount=type=secret,id=netrc,target=/root/.netrc \
-    apk add --upgrade --no-cache apk-tools &&  \
+    apk add --upgrade --no-cache apk-tools && \
     apk update && \
     apk add --no-cache linux-headers gcc g++ python3-dev py3-pip musl-dev libffi-dev openssl-dev git jq curl openssh-client && \
     apk -U upgrade --no-cache && \
-    python3 -m pip install --upgrade pip && \
-    pip3 install --no-cache-dir -U pip && \
-    pip3 install --no-cache-dir -r requirements.txt && \
-    pip3 list --format freeze
-RUN pip3 install --no-cache-dir . && \
-    pip3 list --format freeze && \
+    python3 -m pip install --no-cache-dir --upgrade --user pip -c constraints.txt && \
+    python3 -m pip list --format freeze && \
+    python3 -m pip install --no-cache-dir -r requirements.txt && \
+    python3 -m pip list --format freeze && \
+    python3 -m pip install --no-cache-dir -c constraints.txt /app/*.whl && \
+    python3 -m pip list --format freeze && \
     rm -rf /app/*
 USER nobody:nobody
 ENTRYPOINT [ "python3", "-m", "cfsssh.setup.service" ]

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -2,7 +2,7 @@
  *
  *  MIT License
  *
- *  (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+ *  (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a
  *  copy of this software and associated documentation files (the "Software"),
@@ -57,6 +57,7 @@ pipeline {
         DOCKER_BUILDKIT = "1"
         // Extract the Python version from setup.py
         PY_VERSION = sh(returnStdout: true, script: "grep -Eo 'Programming Language :: Python :: [1-9][0-9]*[.][0-9][0-9]*' setup.py | grep -Eo '[1-9][0-9]*[.][0-9][0-9]*'").trim()
+        PYTHON_MODULE_NAME = "cfs-ssh-trust"
     }
 
     stages {
@@ -82,7 +83,8 @@ pipeline {
             steps { runLint() }
         }
 
-        stage("Python module") {
+        // The Python module is built first because it is used to make the Docker image and RPM
+        stage("Build Python module") {
             agent {
                 docker {
                     label 'python'
@@ -90,37 +92,10 @@ pipeline {
                     reuseNode true
                 }
             }
-            environment {
-                PYTHON_MODULE_NAME = "cfs-ssh-trust"
-                BUILD_METADATA = getRpmRevision(isStable: env.IS_STABLE)
-            }
-            stages {
-
-                stage("Prepare") {
-                    steps {
-                        sh "make prepare"
-                    }
-                }
-
-                stage('Build Python Module') {
-                    steps { sh "make pymod" }
-                }
-
-                stage('Publish Python Module') {
-                    steps {
-                        publishCsmPythonModules(module: env.PYTHON_MODULE_NAME, isStable: env.IS_STABLE)
-                    }
-                }
-            }
-        }
-
-        stage("Add RPM Metadata") {
             steps {
-                echo "RPM build metadata is ${env.BUILD_METADATA}"
-                runLibraryScript("addRpmMetaData.sh", "")
+                sh "make pymod"
             }
         }
-
         stage("Build Chart, Image, and RPMs") {
             parallel {
                 stage('Image') {
@@ -152,6 +127,8 @@ pipeline {
                         }
                     }
                     steps {
+                        echo "RPM build metadata is ${env.BUILD_METADATA}"
+                        runLibraryScript("addRpmMetaData.sh", "")
                         sh "make rpm"
                     }
                 }
@@ -177,6 +154,11 @@ pipeline {
                     steps {
                         publishCsmRpms(component: env.NAME, pattern: "dist/rpmbuild/RPMS/noarch/*.rpm", os: "noos", arch: "noarch", isStable: env.IS_STABLE)
                         publishCsmRpms(component: env.NAME, pattern: "dist/rpmbuild/SRPMS/*.rpm", os: "noos", arch: "src", isStable: env.IS_STABLE)
+                    }
+                }
+                stage('Publish Python Module') {
+                    steps {
+                        publishCsmPythonModules(module: env.PYTHON_MODULE_NAME, isStable: env.IS_STABLE)
                     }
                 }
             }

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+include README.md
+include gitInfo.txt
+include .version
+include requirements.txt

--- a/constraints.txt
+++ b/constraints.txt
@@ -13,6 +13,7 @@ python-dateutil==2.8.2
 PyYAML==6.0.1
 requests==2.25.1
 requests-oauthlib==1.3.1
+requests-retry-session>=0.1.4,<0.2
 rsa==4.7.2
 six==1.16.0
 urllib3==1.26.16

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 --trusted-host artifactory.algol60.net
 --extra-index-url http://artifactory.algol60.net/artifactory/csm-python-modules/simple
 -c constraints.txt
+kubernetes
 liveness
 requests
-kubernetes
+requests-retry-session

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020-2022, 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -22,16 +22,25 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 # setup.py for cfsssh-setup
+from os import path
 import setuptools
 
-with open("README.md", "r") as fh:
+here = path.abspath(path.dirname(__file__))
+
+with open(path.join(here, "README.md"), "r") as fh:
     long_description = fh.read().strip()
 
-with open("gitInfo.txt", "r") as fh:
+with open(path.join(here, "gitInfo.txt"), "r") as fh:
     long_description += '\n' + fh.read()
 
-with open(".version", "r") as fh:
+with open(path.join(here, ".version"), "r") as fh:
     version_str = fh.read()
+
+with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
+    install_requires = []
+    for line in f.readlines():
+        if line and line[0].isalpha():
+            install_requires.append(line.strip())
 
 package_dir = {'cfsssh':                        'src/cfsssh',
                'cfsssh.cloudinit':              'src/cfsssh/cloudinit',
@@ -51,6 +60,7 @@ setuptools.setup(
     url="https://github.com/Cray-HPE/cfs-trust",
     package_dir = package_dir,
     packages = list(package_dir.keys()),
+    install_requires=install_requires,
     keywords="vault ssh cfs kubernetes trust certificates",
     classifiers=[
         "Programming Language :: Python :: 3.6",

--- a/src/cfsssh/connection.py
+++ b/src/cfsssh/connection.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020-2022, 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -31,80 +31,12 @@ Created on Nov 2, 2020
 
 @author: jsl
 '''
+from requests_retry_session import requests_retry_session as base_requests_retry_session
+from functools import partial
 
-import requests
-import logging
-from requests.adapters import HTTPAdapter
-from requests.packages.urllib3.util.retry import Retry
-
-LOGGER = logging.getLogger(__name__)
 PROTOCOL = 'http'
 
-def requests_retry_session(retries=128, backoff_factor=0.01,
-                           status_forcelist=(500, 502, 503, 504),
-                           session=None, pattern='%s://' % (PROTOCOL)):
-    session = session or requests.Session()
-    retry = RetryWithLogs(
-        total=retries,
-        backoff_factor=backoff_factor,
-        status_forcelist=status_forcelist,
-    )
-    adapter = HTTPAdapter(max_retries=retry)
-    session.mount(pattern, adapter)
-    return session
-
-
-class RetryWithLogs(Retry):
-    """
-    This is a urllib3.utils.Retry adapter that allows us to modify the behavior of
-    what happens during retry. By overwriting the superclassed method increment, we
-    can provide the user with information about how frequently we are reattempting
-    an endpoint.
-
-    Providing this feedback to the user allows us to dramatically increase the number
-    of retry operations within the provided call to an attempted upstream API, and
-    gives users a chance to intervene on behalf of the slower upstream service. This
-    behavior is consistent with existing retry behavior that is expected by all of our
-    API interactions, as well, gives us a more immediate sense of feedback for overall
-    system instability and network congestion.
-    """
-    def __init__(self, *args, **kwargs):
-        # Save a copy of upstack callback to the side; this is the context we provide
-        # for recursively instantiated instances of the Retry model
-        self._callback = kwargs.pop('callback', None)
-        super(RetryWithLogs, self).__init__(*args, **kwargs)
-
-    def new(self, *args, **kwargs):
-        # Newly created instances should have a history of callbacks made.
-        kwargs['callback'] = self._callback
-        return super(RetryWithLogs, self).new(*args, **kwargs)
-
-    def increment(self, method, url, *args, **kwargs):
-        pool = kwargs['_pool']
-        endpoint = "%s://%s%s" % (pool.scheme, pool.host, url)
-        try:
-            response = kwargs['response']
-            LOGGER.warning("Previous %s attempt on '%s' resulted in %s response.", method, endpoint, response.status)
-            LOGGER.info("Reattempting %s request for '%s'", method, endpoint)
-        except KeyError:
-            LOGGER.info("Reattempting %s request for '%s'", method, endpoint)
-        if self._callback:
-            try:
-                self._callback(url)
-            except Exception:
-                # This is a general except block
-                LOGGER.exception("Callback to '%s' raised an exception, ignoring.", url)
-        return super(RetryWithLogs, self).increment(method, url, *args, **kwargs)
-
-
-if __name__ == '__main__':
-    import sys
-    lh = logging.StreamHandler(sys.stdout)
-    lh.setLevel(logging.DEBUG)
-    LOGGER.addHandler(lh)
-    LOGGER.setLevel(logging.DEBUG)
-    LOGGER.info("Running")
-    retry_session = requests_retry_session()
-    LOGGER.info(retry_session.get('https://httpstat.us/200').status_code)
-    retry_session = requests_retry_session(retries=5)
-    LOGGER.info(retry_session.get('https://httpstat.us/503').status_code)
+requests_retry_session = partial(base_requests_retry_session,
+                                 protocol=PROTOCOL,
+                                 retries=128,
+                                 backoff_factor=0.01)


### PR DESCRIPTION
This is the same as what was done in `cfs-operator` with [this PR](https://github.com/Cray-HPE/cfs-operator/pull/133), except in this case it was slightly more involved because of the RPM involved, and the additional dependency on liveness. So I had to make some changes to how the RPM and Python package were built. But there are no functional changes.