### PR TITLE
CASMCMS-9292: Avoid BSS issue by changing how global metadata key is retrieved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- CASMCMS-9292: When retrieving BSS global metadata, correctly pass in the key parameter
+  (requires BSS containing fix for CASMHMS-6386).
 
 ### Dependencies
 - Require `requests-retry-session` 0.2.4, which has an important fix

--- a/src/cfsssh/cloudinit/bss.py
+++ b/src/cfsssh/cloudinit/bss.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020-2022, 2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -29,6 +29,10 @@ Created on Nov 17, 2020
 '''
 
 import json
+from typing import Optional
+
+import requests
+
 from cfsssh.connection import requests_retry_session
 from cfsssh.context import in_cluster
 
@@ -52,17 +56,16 @@ class BSSException(Exception):
     This allows us a clean way to retry these interactions.
     """
 
-def get_global_metadata_key(key, session=None):
+def get_global_metadata_key(key: str, session: Optional[requests.Session]=None) -> str:
     session = session or requests_retry_session()
-    get_payload = {'key': 'Global.%s' %(key)}
-    response = session.get(METADATA_ENDPOINT, json=get_payload)
-    try:
+    get_params = {'key': f'Global.{key}'}
+    response = session.get(METADATA_ENDPOINT, params=get_params)
+    try:    
+        # The request will return with a 404 if the key isn't defined
         response.raise_for_status()
     except Exception as exc:
         raise BSSException(exc) from exc
-    obj = json.loads(response.text)
-    # This will raise a key error if it isn't defined!
-    return obj['Global'][key]
+    return json.loads(response.text)
 
 def patch_global_metadata_key(key, value, session=None):
     session = session or requests_retry_session()


### PR DESCRIPTION
The full discussion of this issue can be found in [this Slack thread](https://cray.slack.com/archives/CJWJB3DUP/p1740010285521849).

The short version is that when `cfs-trust` queries BSS for meta-data, it only cares about the Global stanza, but its current query includes more than just that. Because of this, and because of a quirk of our Kubernetes networking, BSS ends up doing a lot of unnecessary extra work when handling these requests. On large scale systems, this can add up to a lot of superfluous work for BSS.

The problem with the current cfs-trust query is two-fold:

1. It uses the `json` argument to the `get` function. This puts the payload into the request body. However, as is usually the case for GET requests, GET requests to this endpoint do not accept any inputs via the request body. So the stuff being passed in by cfs-trust is ignored by BSS and has no effect.

2. Due to a bug in BSS ([CASMHMS-6386](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6386)), specifying the type of parameter that `cfs-trust `does will result in a 404 error.

Since the BSS bug is being fixed for CSM 1.7, for this PR to develop, I am going to only address the first issue. I have already tested this on mug, with the BSS fix from @jwlv , and verified that it works.

The backports for this will differ slightly. See the CSM 1.6 backport PR for details. Backports:

CSM 1.6: https://github.com/Cray-HPE/cfs-trust/pull/81
CSM 1.5: https://github.com/Cray-HPE/cfs-trust/pull/82

For the backports to previous CSM versions, even though the BSS fix is being backported, I don't want to introduce this dependency between the `cfs-trust` version and the BSS version. This is mainly in case we need to provide a `cfs-trust` hotfix to a customer who doesn't have a BSS that includes the fix. I don't want to force us to either include BSS in the hotfix or make some one-off version of `cfs-trust` that reverts this PR but addresses whatever issue the customer is facing.

So for the backports to previous CSM versions, I will instead have `cfs-trust` specify a `key` parameter of just `Global`. Changes are being made on the BSS side to make it see this, and avoid doing the unnecessary work in cases where only Global data is desired. But the code change on the cfs-trust side can happen even before that, because the change doesn't rely on the BSS changes.

I have also tested that version of the change on mug and verified that it works.