### PR TITLE
CASMCMS-9293: Use default values for retries and backoff_factor, instead of the current aggressive overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- CASMCMS-9293: Use default values for `retries` and `backoff_factor`, instead of the current aggressive overrides
 
 ### Dependencies
 - Require `requests-retry-session` 0.2.4, which has an important fix

--- a/src/cfsssh/connection.py
+++ b/src/cfsssh/connection.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020-2022, 2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020-2022, 2024-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -32,6 +32,7 @@ Created on Nov 2, 2020
 @author: jsl
 '''
 
+from functools import partial
 import logging
 
 from requests_retry_session import requests_retry_session as base_requests_retry_session
@@ -39,12 +40,7 @@ from requests_retry_session import requests_retry_session as base_requests_retry
 LOGGER = logging.getLogger(__name__)
 PROTOCOL = 'http'
 
-def requests_retry_session(retries=128, backoff_factor=0.01, **kwargs):
-    return base_requests_retry_session(protocol=PROTOCOL,
-                                       retries=retries,
-                                       backoff_factor=backoff_factor,
-                                       **kwargs)
-
+requests_retry_session = partial(base_requests_retry_session, protocol=PROTOCOL)
 
 if __name__ == '__main__':
     import sys


### PR DESCRIPTION
As part of the investigation into [CAST-37722](https://jira-pro.it.hpe.com:8443/browse/CAST-37722), we discovered that cfs-trust was making a large number of calls to BSS in a short period of time. These were retries of unsuccessful requests. It is intended to retry on failure, but it is using a backoff factor of 0.01, which led to over 100 requests in around 10 seconds. This does not seem like desirable behavior.

I will note that the retry values being used by cfs-trust have been the same since at least CSM 0.9, so this isn't anything new. And obviously when BSS is responding, it never comes into play. But if BSS is experiencing problems, this aggressive retry setting can exacerbate those problems, and make it harder for BSS to recover (especially on larger scale systems, where thousands of clients are potentially making these barrage of retries).

This PR changes it so that it uses the default values for retries and backoff factor (like most of our other services do).

I tested this on mug and verified that it works.