### PR TITLE
CASMCMS-9292/CASMCMS-9293 backport for CSM 1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - CASMCMS-9292: When retrieving BSS global metadata, correctly pass in the key parameter.
+- CASMCMS-9293: Use default values for `retries` and `backoff_factor`, instead of the current aggressive overrides
 
 ### Dependencies
 - Require `requests-retry-session` 0.2.4, which has an important fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- CASMCMS-9292: When retrieving BSS global metadata, correctly pass in the key parameter.
 
 ### Dependencies
 - Require `requests-retry-session` 0.2.4, which has an important fix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.7.6] - 2025-02-26
 ### Changed
 - CASMCMS-9292: When retrieving BSS global metadata, correctly pass in the key parameter.
 - CASMCMS-9293: Use default values for `retries` and `backoff_factor`, instead of the current aggressive overrides

--- a/src/cfsssh/cloudinit/bss.py
+++ b/src/cfsssh/cloudinit/bss.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020-2022, 2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -29,6 +29,10 @@ Created on Nov 17, 2020
 '''
 
 import json
+from typing import Optional
+
+import requests
+
 from cfsssh.connection import requests_retry_session
 from cfsssh.context import in_cluster
 
@@ -52,17 +56,17 @@ class BSSException(Exception):
     This allows us a clean way to retry these interactions.
     """
 
-def get_global_metadata_key(key, session=None):
+def get_global_metadata_key(key: str, session: Optional[requests.Session]=None) -> str:
     session = session or requests_retry_session()
-    get_payload = {'key': 'Global.%s' %(key)}
-    response = session.get(METADATA_ENDPOINT, json=get_payload)
+    get_params = {'key': 'Global'}
+    response = session.get(METADATA_ENDPOINT, params=get_params)
     try:
         response.raise_for_status()
     except Exception as exc:
         raise BSSException(exc) from exc
     obj = json.loads(response.text)
     # This will raise a key error if it isn't defined!
-    return obj['Global'][key]
+    return obj[key]
 
 def patch_global_metadata_key(key, value, session=None):
     session = session or requests_retry_session()

--- a/src/cfsssh/connection.py
+++ b/src/cfsssh/connection.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2020-2022, 2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2020-2022, 2024-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -32,6 +32,7 @@ Created on Nov 2, 2020
 @author: jsl
 '''
 
+from functools import partial
 import logging
 
 from requests_retry_session import requests_retry_session as base_requests_retry_session
@@ -39,12 +40,7 @@ from requests_retry_session import requests_retry_session as base_requests_retry
 LOGGER = logging.getLogger(__name__)
 PROTOCOL = 'http'
 
-def requests_retry_session(retries=128, backoff_factor=0.01, **kwargs):
-    return base_requests_retry_session(protocol=PROTOCOL,
-                                       retries=retries,
-                                       backoff_factor=backoff_factor,
-                                       **kwargs)
-
+requests_retry_session = partial(base_requests_retry_session, protocol=PROTOCOL)
 
 if __name__ == '__main__':
     import sys


### PR DESCRIPTION
For [CASMCMS-9293](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9293), this is a straight backport of [the CSM 1.7 CASMCMS-9293 PR](https://github.com/Cray-HPE/cfs-trust/pull/80). See that PR for details.

For [CASMCMS-9292](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9292), this is not an exact backport of the changes in [the CSM 1.7 CASMCMS-9292 PR](https://github.com/Cray-HPE/cfs-trust/pull/79). See that PR for a full background of the problem and how it is being addressed in CSM 1.7. Here I will explain how this backport (and [the CSM 1.5 backport](https://github.com/Cray-HPE/cfs-trust/pull/82)) differ from the primary PR.

Even though the BSS fix is being backported, I don't want to introduce this dependency between the `cfs-trust` version and the BSS version. This is mainly in case we need to provide a `cfs-trust` hotfix to a customer who doesn't have a BSS that includes the fix. I don't want to force us to either include BSS in the hotfix or make some one-off version of `cfs-trust` that reverts this PR but addresses whatever issue the customer is facing.

So for the backports, I instead have `cfs-trust` specify a `key` parameter of just `Global`. Changes are being backported on the BSS side to avoid doing the unnecessary work in cases where only Global data is desired. But the code change on the `cfs-trust` side can happen even before that, because the change doesn't rely on the BSS changes -- it will work either way. The BSS inefficiencies will just exist (as they currently do) if the BSS fix is not present.

I have also tested that version of the change on mug and verified that it works.