### PR TITLE
CASMCMS-9333: get_global_metadata_key must raise KeyError when Global cfs_public_key is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.9.1] - 2025-03-27
 ### Fixed
 - CASMCMS-9333: `get_global_metadata_key` must raise `KeyError` when `Global.cfs_public_key` is missing
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- CASMCMS-9333: `get_global_metadata_key` must raise `KeyError` when `Global.cfs_public_key` is missing
+
 ## [1.9.0] - 2025-02-27
 ### Changed
 - CASMCMS-9293: Use default values for `retries` and `backoff_factor`, instead of the current aggressive overrides


### PR DESCRIPTION
Prior to the changes made in [CASMCMS-9292](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9292)/[CASMHMS-6386](https://jira-pro.it.hpe.com:8443/browse/CASMHMS-6386), when no `cfs_public_key` was found in the BSS Global metadata, the `get_global_metadata_key` function raised a `KeyError`. Due to the changes made in those tickets, BSS now returns a 404 in this case, and this results in a different exception being raised. This breaks the `cfs-trust` service, which relies on the `KeyError` [to detect the missing key and repopulate it](https://github.com/Cray-HPE/cfs-trust/blob/v1.9.0/src/cfsssh/setup/service/__main__.py#L73-L94).

This PR updates the function to raise a `KeyError` when BSS returns 404 to this query.

I tested this on wasp and verifies that it fixes all of the problems reported in [CASMTRIAGE-8007](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8007), which is the ticket which made us aware of the problem.